### PR TITLE
Fixing unexpected behavior of binsacc when either either sacl or sacr is empty list

### DIFF
--- a/EngbertMicrosaccadeToolbox/microsac_detection.py
+++ b/EngbertMicrosaccadeToolbox/microsac_detection.py
@@ -206,61 +206,101 @@ def _mark_combined_sacs(ixes_r, ixes_l):
 
 
 def binsacc(sacl, sacr):
-    ixes_l = np.array([np.array([s[0], s[1]]) for s in sacl])
-    ixes_r = np.array([np.array([s[0], s[1]]) for s in sacr])
+    """find binocular microsaccades
+
+    Parameters
+    ----------
+    sacl : list 
+        events for left eye
+    sacr : list
+        events for right eye
+    
+
+    Returns
+    -------
+    list
+        binocular events with [ (1) onset, (2) end, (3) peak velocity,
+                                (4) horizontal component, (5) vertical component,
+                                (6) horizontal amplitude, (6) vertical amplitude,
+
+                                (1) onset, (2) end, (3) peak velocity,
+                                (4) horizontal component, (5) vertical component,
+                                (6) horizontal amplitude, (6) vertical amplitude]]
+    list
+        left eye monocular events with [(1) onset, (2) end, (3) peak velocity,
+                                        (4) horizontal component, (5) vertical component,
+                                        (6) horizontal amplitude, (6) vertical amplitude]
+    list
+        right eye monocular events with [(1) onset, (2) end, (3) peak velocity,
+                                         (4) horizontal component, (5) vertical component,
+                                         (6) horizontal amplitude, (6) vertical amplitude]
+    """
 
     NB = 0
     NR = 0
     NL = 0
-    if (len(sacr) != 0) and (len(sacl) != 0):
-        s = _mark_combined_sacs(ixes_l, ixes_r)
-        # Find onsets and offsets of microsaccades
-        onoff = np.where(np.diff(s) != 0)[0]
-        m = onoff.reshape((-1, 2))
-        N = m.shape[0]
 
-        # Determine binocular saccades
-        bino = []
-        monol = []
-        monor = []
-        for i in range(N):
-            left = np.where(np.logical_and((m[i, 0] <= ixes_l[:, 0]),
-                                           (ixes_l[:, 1] <= m[i, 1])))[0]
-            right = np.where(np.logical_and((m[i, 0] <= ixes_r[:, 0]),
-                                            (ixes_r[:, 1] <= m[i, 1])))[0]
-            # Binocular saccades
-            if len(left) > 0 and len(right) > 0:
-                ampl = 0
-                l_ix = 0
-                for il, l in enumerate(left):
-                    new_ampl = np.sqrt(sacl[l][5]**2 + sacl[l][6]**2)
-                    if new_ampl > ampl:
-                        ampl = new_ampl
-                        l_ix = il
+    bino = []
+    monol = []
+    monor = []
 
-                ampr = 0
-                r_ix = 0
-                for ir, r in enumerate(right):
-                    new_ampr = np.sqrt(sacr[r][5]**2 + sacr[r][6]**2)
-                    if new_ampr > ampr:
-                        ampr = new_ampr
-                        r_ix = ir
-                NB += 1
-                combined = list(sacl[left[l_ix]])
-                combined.extend(list(sacr[right[r_ix]]))
-                bino.append(combined)
-            else:
-                if len(left) == 0:
-                    assert len(right) == 1
-                    ampr = np.sqrt(sacr[right[0]][5]**2 + sacr[right[0]][6]**2)
-                    NR += 1
-            #           ir <- which.max(ampr)
-                    monor.append(list(sacr[right[0]]))
-                if len(right) == 0:
-                    assert len(left) == 1
-                    ampl = np.sqrt(sacl[left[0]][5]**2 + sacl[left[0]][6]**2)
-                    NL += 1
-                    monol.append(list(sacl[left[0]]))
+    # Return early for exclusively monocluar saccades
+    if not sacl:
+        monor = sacr
+        return bino, monol, monor
+
+    if not sacr:
+        monol = sacl
+        return bino, monol, monor
+
+    # Mark combined saccades
+    ixes_l = np.array([np.array([s[0], s[1]]) for s in sacl])
+    ixes_r = np.array([np.array([s[0], s[1]]) for s in sacr])
+    s = _mark_combined_sacs(ixes_l, ixes_r)
+    # Find onsets and offsets of microsaccades
+    onoff = np.where(np.diff(s) != 0)[0]
+    m = onoff.reshape((-1, 2))
+    N = m.shape[0]
+
+    # Determine binocular saccades
+    for i in range(N):
+        left = np.where(np.logical_and((m[i, 0] <= ixes_l[:, 0]),
+                                        (ixes_l[:, 1] <= m[i, 1])))[0]
+        right = np.where(np.logical_and((m[i, 0] <= ixes_r[:, 0]),
+                                        (ixes_r[:, 1] <= m[i, 1])))[0]
+        # Binocular saccades
+        if len(left) > 0 and len(right) > 0:
+            ampl = 0
+            l_ix = 0
+            for il, l in enumerate(left):
+                new_ampl = np.sqrt(sacl[l][5]**2 + sacl[l][6]**2)
+                if new_ampl > ampl:
+                    ampl = new_ampl
+                    l_ix = il
+
+            ampr = 0
+            r_ix = 0
+            for ir, r in enumerate(right):
+                new_ampr = np.sqrt(sacr[r][5]**2 + sacr[r][6]**2)
+                if new_ampr > ampr:
+                    ampr = new_ampr
+                    r_ix = ir
+            NB += 1
+            combined = list(sacl[left[l_ix]])
+            combined.extend(list(sacr[right[r_ix]]))
+            bino.append(combined)
+        else:
+            if len(left) == 0:
+                assert len(right) == 1
+                ampr = np.sqrt(sacr[right[0]][5]**2 + sacr[right[0]][6]**2)
+                NR += 1
+        #           ir <- which.max(ampr)
+                monor.append(list(sacr[right[0]]))
+            if len(right) == 0:
+                assert len(left) == 1
+                ampl = np.sqrt(sacl[left[0]][5]**2 + sacl[left[0]][6]**2)
+                NL += 1
+                monol.append(list(sacl[left[0]]))
     return bino, monol, monor
 
 

--- a/tests/test_against_r.py
+++ b/tests/test_against_r.py
@@ -65,7 +65,9 @@ def test_binsacc():
     input_array_r = np.genfromtxt("tests/sacr.dat")
     input_array_l[:, 0:2] = input_array_l[:, 0:2] - 1
     input_array_r[:, 0:2] = input_array_r[:, 0:2] - 1
-    bino, monol, monor = microsac_detection.binsacc(input_array_l, input_array_r)
+    input_list_l = input_array_l.tolist()
+    input_list_r = input_array_r.tolist()
+    bino, monol, monor = microsac_detection.binsacc(input_list_l, input_list_r)
     expected_bino = np.genfromtxt("tests/bino.dat")
     expected_bino[:, 0:2] = expected_bino[:, 0:2] - 1
     expected_bino[:, 7:9] = expected_bino[:, 7:9] - 1
@@ -74,6 +76,19 @@ def test_binsacc():
     np.testing.assert_allclose(expected_bino, np.array(bino))
     np.testing.assert_allclose(expected_monol, np.array(monol))
     assert monor == []
+
+    # edge case input_array_l = []
+    bino, monol, monor = microsac_detection.binsacc([], input_list_r)
+    assert bino == []
+    assert monol == []
+    np.testing.assert_allclose(input_list_r, np.array(monor))
+
+    # edge case input_array_r = []
+    bino, monol, monor = microsac_detection.binsacc(input_list_l, [])
+    assert bino == []
+    np.testing.assert_allclose(input_list_l, np.array(monol))
+    assert monor == []
+    
 
 def test_sacpar():
     input_array = np.genfromtxt("tests/sacpar_in.dat")


### PR DESCRIPTION
The original function assigns the input list of events to the monocular output of binsacc when one of the inputs is empty. The binocular output is then also empty. Here, the function threw an error when one of the input lists is empty, because the main body of the function does not run, and the output lists are not instantiated. Therefore, two guard clauses were added for an early return. Both edge cases are tested. For completeness, a function description was added.